### PR TITLE
bugfix/30-fix-summary-display-in-different-modes

### DIFF
--- a/upace/screens/timeCalc/timeSummary.js
+++ b/upace/screens/timeCalc/timeSummary.js
@@ -33,7 +33,7 @@ const TimeSummary = ({ containerStyle }) => {
         const displayMinutes = minutes !== "";
 
         let seconds = "";
-        if (hasSeconds || timeSpan.seconds > 0)
+        if (hasSeconds || timeSpan.seconds > 0 || hasMilliSeconds)
             seconds = `${displayMinutes ? ":" : ""}${
                 displayMinutes && timeSpan.seconds < 10 ? `0${timeSpan.seconds}` : timeSpan.seconds
             }`;


### PR DESCRIPTION
Fixes: second didn't display when only minutes and seconds were entered 

closes #30 